### PR TITLE
feat: adding retinopahy detail interface

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,4 @@
-import { Stack } from "expo-router";
-import { View, Text, TouchableOpacity, Image } from "react-native";
-import { MaterialIcons, Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from "expo-router";
 
 export default function HomeLayout() {
   const router = useRouter();
@@ -25,7 +22,7 @@ export default function HomeLayout() {
       />
       
       <Stack.Screen
-        name="prediction"
+        name="retinopatia"
         options={{
           headerShown: false,  // ← Deshabilitar header para prediction
         }}

--- a/app/(tabs)/chatai.tsx
+++ b/app/(tabs)/chatai.tsx
@@ -1,22 +1,22 @@
 // app/(tabs)/chatai.tsx
-import React, { useState, useEffect } from 'react';
+import { Stack, useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
 import {
-  View,
-  SafeAreaView,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
-  Keyboard,
+  SafeAreaView,
+  View,
 } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
 
 // Importar componentes core
 import { DashboardHeader } from '@/features/dashboard/components/DashboardHeader';
 import { NavButton } from '@/features/dashboard/components/NavButton';
 
 // Importar componentes del chat
-import { 
-  ChatMessagesList,
-  ChatInput 
+import {
+  ChatInput,
+  ChatMessagesList
 } from '@/features/dashboard/components';
 
 const AIChat = () => {
@@ -154,7 +154,7 @@ const AIChat = () => {
                       title="Predicción"
                       iconName="box"
                       isActive={activeTab === 'predicción'}
-                      onPress={() => handleNavigation('predicción', '/(tabs)/prediction')}
+                      onPress={() => handleNavigation('predicción', '/(tabs)/retinopatia')}
                     />
                     <NavButton
                       title="Historial"

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -167,7 +167,7 @@ const Dashboard = () => {
           style={{ width: 375, height: 67 }}
         >
           <NavButton title="Inicio" iconName="home" isActive={activeTab === 'inicio'} onPress={() => handleNavigation('inicio')} />
-          <NavButton title="Predicción" iconName="box" isActive={activeTab === 'predicción'} onPress={() => handleNavigation('predicción', '/(tabs)/prediction')} />
+          <NavButton title="Predicción" iconName="box" isActive={activeTab === 'predicción'} onPress={() => handleNavigation('predicción', '/(tabs)/retinopatia')} />
           <NavButton title="Historial" iconName="activity" isActive={activeTab === 'historial'} onPress={() => handleNavigation('historial', '/(tabs)/record')} />
           <NavButton title="IA Chat" iconName="codesandbox" isActive={activeTab === 'ia chat'} onPress={() => handleNavigation('ia chat', '/(tabs)/chatai')} />
         </View>

--- a/app/(tabs)/prediction/nefropatia.tsx
+++ b/app/(tabs)/prediction/nefropatia.tsx
@@ -1,7 +1,7 @@
 // app/(tabs)/prediction/nefropatia.tsx
-import React, { useState } from 'react';
-import { View, ScrollView, SafeAreaView } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { SafeAreaView, ScrollView } from 'react-native';
 
 // Tipografía
 import { H2 } from '@/components/common/Typography';
@@ -11,9 +11,9 @@ import { Header } from '@/components/core/navigation/Header';
 
 // Componentes específicos
 import {
-  RiskLevelCard,
   ComplicationsSection,
-  RecommendationsSection
+  RecommendationsSection,
+  RiskLevelCard
 } from '@/features/dashboard/components';
 
 const Nefropatia = () => {

--- a/app/(tabs)/record.tsx
+++ b/app/(tabs)/record.tsx
@@ -1,13 +1,12 @@
 // app/(tabs)/record.tsx
+import Feather from '@expo/vector-icons/Feather';
+import { Stack, useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import {
-  View,
-  ScrollView,
   SafeAreaView,
+  ScrollView,
+  View,
 } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
-import { Ionicons, MaterialIcons } from '@expo/vector-icons';
-import Feather from '@expo/vector-icons/Feather';
 
 // Importar componentes core
 import { H2 } from '@/components/common/Typography';
@@ -16,8 +15,8 @@ import { NavButton } from '@/features/dashboard/components/NavButton';
 
 // Importar componentes del record
 import {
-  PeriodSelector,
   CategoryTabs,
+  PeriodSelector,
   RecordChart,
   RecordsList,
   StatItem
@@ -101,67 +100,67 @@ const Record = () => {
             xAxisTitle="t (min)"
           />
 
-  <View className="rounded-2xl p-1 mb-4">
-  <H2 className="text-[#2C3E50] font-bold text-lg mb-5">
-    Estadísticas clave ({selectedPeriod})
-  </H2>
+          <View className="rounded-2xl p-1 mb-4">
+            <H2 className="text-[#2C3E50] font-bold text-lg mb-5">
+              Estadísticas clave ({selectedPeriod})
+            </H2>
 
-  {/* Fila 1 */}
-  <View className="flex-row justify-between mb-4">
-    <StatItem
-      icon={<Feather name="activity" size={24} color="#314158" />}
-      value="78%"
-      label="TIR"
-    />
-    <StatItem
-      icon={<Feather name="heart" size={24} color="#314158" />}
-      value="45"
-      label="Lecturas"
-    />
-  </View>
+            {/* Fila 1 */}
+            <View className="flex-row justify-between mb-4">
+              <StatItem
+                icon={<Feather name="activity" size={24} color="#314158" />}
+                value="78%"
+                label="TIR"
+              />
+              <StatItem
+                icon={<Feather name="heart" size={24} color="#314158" />}
+                value="45"
+                label="Lecturas"
+              />
+            </View>
 
-  {/* Fila 2 */}
-  <View className="flex-row justify-between mb-4">
-    <StatItem
-      icon={<Feather name="box" size={24} color="#314158" />}
-      value="6.5%"
-      label="HbA1c Est."
-    />
-    <StatItem
-      icon={<Feather name="hexagon" size={24} color="#314158" />}
-      value="135mg/dL"
-      label="Promedio"
-    />
-  </View>
+            {/* Fila 2 */}
+            <View className="flex-row justify-between mb-4">
+              <StatItem
+                icon={<Feather name="box" size={24} color="#314158" />}
+                value="6.5%"
+                label="HbA1c Est."
+              />
+              <StatItem
+                icon={<Feather name="hexagon" size={24} color="#314158" />}
+                value="135mg/dL"
+                label="Promedio"
+              />
+            </View>
 
-  {/* Fila 3 */}
-  <View className="flex-row justify-between mb-4">
-    <StatItem
-      icon={<Feather name="box" size={24} color="#314158" />}
-      value="4.1/día"
-      label="Promedio"
-    />
-    <StatItem
-      icon={<Feather name="heart" size={24} color="#314158" />}
-      value="32mg/dL"
-      label="Desv. Est."
-    />
-  </View>
+            {/* Fila 3 */}
+            <View className="flex-row justify-between mb-4">
+              <StatItem
+                icon={<Feather name="box" size={24} color="#314158" />}
+                value="4.1/día"
+                label="Promedio"
+              />
+              <StatItem
+                icon={<Feather name="heart" size={24} color="#314158" />}
+                value="32mg/dL"
+                label="Desv. Est."
+              />
+            </View>
 
-  {/* Fila 4 */}
-  <View className="flex-row justify-between mb-2">
-    <StatItem
-      icon={<Feather name="hexagon" size={24} color="#314158" />}
-      value="135mg/dL"
-      label="Promedio"
-    />
-    <StatItem
-      icon={<Feather name="box" size={24} color="#314158" />}
-      value="4.1/día"
-      label="Promedio"
-    />
-  </View>
-</View>
+            {/* Fila 4 */}
+            <View className="flex-row justify-between mb-2">
+              <StatItem
+                icon={<Feather name="hexagon" size={24} color="#314158" />}
+                value="135mg/dL"
+                label="Promedio"
+              />
+              <StatItem
+                icon={<Feather name="box" size={24} color="#314158" />}
+                value="4.1/día"
+                label="Promedio"
+              />
+            </View>
+          </View>
 
 
           {/* Lista de registros */}
@@ -176,30 +175,30 @@ const Record = () => {
           className="bg-white border-t border-gray-200 flex-row shadow-lg self-center"
           style={{ width: 375, height: 67 }}
         >
-   <NavButton
-             title="Inicio"
-             iconName="home"
-             isActive={activeTab === 'inicio'}
+          <NavButton
+            title="Inicio"
+            iconName="home"
+            isActive={activeTab === 'inicio'}
             onPress={() => handleNavigation('home', '/(tabs)/home')}
-           />
-           <NavButton
-             title="Predicción"
-             iconName="box"
-             isActive={activeTab === 'predicción'}
-             onPress={() => handleNavigation('predicción', '/(tabs)/prediction')}
-           />
-           <NavButton
-             title="Historial"
-             iconName="activity"
-             isActive={activeTab === 'historial'}
-             onPress={() => handleNavigation('historial', '/(tabs)/record')}
-           />
-           <NavButton
-             title="IA Chat"
-             iconName="codesandbox"
-             isActive={activeTab === 'ia chat'}
-             onPress={() => handleNavigation('ia chat', '/(tabs)/chatai')}
-           />
+          />
+          <NavButton
+            title="Predicción"
+            iconName="box"
+            isActive={activeTab === 'predicción'}
+            onPress={() => handleNavigation('predicción', '/(tabs)/retinopatia')}
+          />
+          <NavButton
+            title="Historial"
+            iconName="activity"
+            isActive={activeTab === 'historial'}
+            onPress={() => handleNavigation('historial', '/(tabs)/record')}
+          />
+          <NavButton
+            title="IA Chat"
+            iconName="codesandbox"
+            isActive={activeTab === 'ia chat'}
+            onPress={() => handleNavigation('ia chat', '/(tabs)/chatai')}
+          />
         </View>
       </SafeAreaView>
     </>

--- a/app/(tabs)/retinopatia.tsx
+++ b/app/(tabs)/retinopatia.tsx
@@ -1,38 +1,37 @@
-// app/(tabs)/prediction/index.tsx
-import { TrendChart } from '@/features/dashboard/components/TrendChart';
+// app/(tabs)/prediction/retinopatia.tsx
 import { Stack, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
+import { SafeAreaView, ScrollView, View } from 'react-native';
 
-import {
-  SafeAreaView,
-  ScrollView,
-  View
-} from 'react-native';
-
-// Importar componentes core
+// Tipografía
 import { H2 } from '@/components/common/Typography';
 
-// Importar componentes del dashboard existentes
+// Header personalizado
+
+// Componentes específicos
 import {
   ComplicationsList,
+  ComplicationsSection,
   DashboardHeader,
-  NavButton
+  NavButton,
+  RecommendationsSection,
+  RiskLevelCard,
+  TrendChart
 } from '@/features/dashboard/components';
 
-// Importar componentes específicos para Prediction
-import {
-  RiskLevelCard
-} from '@/features/dashboard/components';
 
-const Prediction = () => {
+const Retinopatia = () => {
   const [nivelGeneral, setNivelGeneral] = useState<string>('');
   const [lastUpdate, setLastUpdate] = useState<string>('');
   const [trendData, setTrendData] = useState<any[]>([]);
   const [complicationData, setComplicationData] = useState<any[]>([]);
-  const [selectedRiskType, setSelectedRiskType] = useState<string>('General');
-  const [activeTab, setActiveTab] = useState<string>('predicción');
-
+  const [selectedRiskType, setSelectedRiskType] = useState('Retinopatía');
+  const [activeTab, setActiveTab] = useState('predicción');
+  const [showAllFactors, setShowAllFactors] = useState(true); // Estado para mostrar/ocultar factores
   const router = useRouter();
+
+  const handleNotifications = () => console.log('Abriendo notificaciones…');
+  const handleSettings = () => console.log('Abriendo configuración…');
 
   const fetchPrediction = async () => {
     try {
@@ -48,6 +47,13 @@ const Prediction = () => {
     }
   };
 
+  const complications = [
+    { name: 'Nefropatía diabética', level: 'Bajo', isHigh: false },
+    { name: 'Retinopatía diabética', level: 'Bajo', isHigh: false },
+    { name: 'Neuropatía diabética', level: 'Alto', isHigh: true },
+    { name: 'Pie diabético', level: 'Bajo', isHigh: false }
+  ];
+
   useEffect(() => {
     fetchPrediction();
   }, []);
@@ -56,24 +62,6 @@ const Prediction = () => {
     fetchPrediction();
   };
 
-  const handleNotifications = () => console.log('Abriendo notificaciones...');
-  const handleSettings = () => console.log('Abriendo configuración...');
-
-  // Navegación de tabs
-  const handleNavigation = (tab: string, route?: string) => {
-    setActiveTab(tab.toLowerCase());
-    if (route) router.push(route as any);
-  };
-
-  // Mapeo de complicaciones para el listado
-  const complications = [
-    { name: 'Nefropatía diabética', level: 'Bajo', isHigh: false },
-    { name: 'Retinopatía diabética', level: 'Bajo', isHigh: false },
-    { name: 'Neuropatía diabética', level: 'Alto', isHigh: true },
-    { name: 'Pie diabético', level: 'Bajo', isHigh: false }
-  ];
-
-
   const handleComplicationPress = (complication: string) => {
     const routes: Record<string, string> = {
       'Nefropatía diabética': '/prediction/nefropatia',
@@ -81,13 +69,40 @@ const Prediction = () => {
       'Neuropatía diabética': '/prediction/neuropatia',
       'Pie diabético': '/prediction/pie-diabetico'
     };
-    router.push(routes[complication] || '/(tabs)/prediction/complicacion');
+    router.push((routes[complication] || '/prediction/complicacion') as any);
   };
+
+  const handleViewMore = () => {
+    console.log('Ver más recomendaciones...');
+  };
+
+  const handleToggleFactors = () => {
+    setShowAllFactors(!showAllFactors);
+  };
+
+  const handleNavigation = (tab: string, route?: string) => {
+    setActiveTab(tab.toLowerCase());
+    if (route) router.push(route as any);
+  };
+
+  // Datos específicos de retinopatía con valores/descripciones
+  const retinopatiaFactors = [
+    { name: 'HbA1c promedio', level: 'Moderado', isHigh: false, value: '6.5%' },
+    { name: 'Tiempo en rango (TIR)', level: 'Moderado', isHigh: false, value: '78%' },
+    { name: 'Presión arterial', level: 'Alto', isHigh: true, value: '140/90 mmHg' },
+    { name: 'Presión arterial', level: 'Alto', isHigh: true, value: '78%' }
+  ];
+
+  // Datos de recomendaciones
+  const recommendations = [
+    "Controla tu presión arterial regularmente.",
+    "Mantén tu glucosa en rango para proteger tus riñones.",
+    "Pregunta a tu médico sobre medicamentos que protejan la función renal."
+  ];
 
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-
       <SafeAreaView className="flex-1 bg-[#f1f5f9]">
         <DashboardHeader
           onNotificationPress={handleNotifications}
@@ -100,7 +115,7 @@ const Prediction = () => {
           contentContainerStyle={{ paddingBottom: 100 }}
         >
           <H2 className="text-[#2C3E50] font-bold text-lg mt-6 mb-5">
-            Tu nivel de riesgo general
+            Tu nivel de riesgo de retinopatía diabética
           </H2>
 
           {nivelGeneral !== '' && (
@@ -123,12 +138,32 @@ const Prediction = () => {
             Tendencia histórica de riesgo
           </H2>
           {/* <DropdownSelector
-            selectedValue={selectedRiskType}
-            onPress={() => }
-            placeholder="Seleccionar tipo de riesgo"
-          /> */}
+                    selectedValue={selectedRiskType}
+                    onPress={() => }
+                    placeholder="Seleccionar tipo de riesgo"
+                  /> */}
           <TrendChart data={trendData} selectedType={selectedRiskType} />
+
+          <ComplicationsSection
+            title="Factores que influyen en la retinopatía"
+            complications={retinopatiaFactors}
+            showAll={showAllFactors}
+            onToggleView={handleToggleFactors}
+            buttonText={showAllFactors ? "Ver menos" : "Ver más"}
+            onComplicationPress={handleComplicationPress}
+            showArrow={false}
+          />
+
+          <RecommendationsSection
+            title="Recomendaciones para regular la retinopatía"
+            recommendations={recommendations}
+            onViewMore={handleViewMore}
+            buttonTitle="Ver más"
+          />
+
         </ScrollView>
+
+
 
         <View
           className="bg-white border-t border-gray-200 flex-row shadow-lg self-center"
@@ -164,4 +199,4 @@ const Prediction = () => {
   );
 };
 
-export default Prediction;
+export default Retinopatia;

--- a/src/features/dashboard/components/ComplicationsList.tsx
+++ b/src/features/dashboard/components/ComplicationsList.tsx
@@ -1,7 +1,7 @@
 // src/features/dashboard/components/ComplicationsList.tsx
-import React from 'react';
-import { View, TouchableOpacity, Text } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 interface Complication {
   name: string;


### PR DESCRIPTION
📝 **1. ¿Qué hace este cambio?**
This update modifies the navigation behavior in the mobile application so that the bottom navigation button that previously routed to /prediction now correctly routes to the /prediction/retinopatia screen.

🎯 **2. ¿Por qué se hace este cambio?**
This change was made because it was decided to use the retinopatia route instead of the generic prediction route, in order to go directly to the diabetic retinopathy screen.

🔍 **3. ¿Cómo verificar el cambio?**
1. Run the mobile app using npx expo start.
2. Tap the corresponding icon/button in the bottom navigation bar that used to open /prediction.
3. Confirm that the app now opens the retinopatia.tsx screen directly, instead of the default prediction view.

✅ **4. Checklist de control**
- [x] Mi código funciona.
- [x] Hice una revisión rápida de mis propios cambios.
- [ ] La documentación relevante fue actualizada (si aplica).
